### PR TITLE
On demand data refetch idea

### DIFF
--- a/web/pages/api/revalidate.ts
+++ b/web/pages/api/revalidate.ts
@@ -1,0 +1,32 @@
+import { NextApiRequest, NextApiResponse } from 'next';
+
+type ResponseData = {
+  revalidated?: boolean;
+  message?: string;
+};
+
+export default async function handler(
+  req: NextApiRequest,
+  res: NextApiResponse<ResponseData | string>
+) {
+  // Check for secret to confirm this is a valid request
+  if (req.query.secret !== process.env.MY_SECRET_TOKEN) {
+    return res.status(401).json({ message: 'Invalid token' });
+  }
+
+  // grab slug from query string
+  if (!req.query.slug) {
+    return res.status(400).json({ message: 'Missing slug' });
+  }
+
+  try {
+    // this should be the actual path not a rewritten path
+    // e.g. for "/blog/[slug]" this should be "/blog/post-1"
+    await res.revalidate(req.query.slug as string);
+    return res.json({ revalidated: true });
+  } catch (err) {
+    // If there was an error, Next.js will continue
+    // to show the last successfully generated page
+    return res.status(500).send('Error revalidating');
+  }
+}


### PR DESCRIPTION
- Client side we call the json_uri and check the description field. If the description field is different than the one passed in by getStaticProps, it calls revalidate
- Revalidate api route regenerates a page based on the slug

[https://nextjs.org/docs/pages/building-your-application/data-fetching/incremental-static-regeneration#using-on-demand-revalidation](https://nextjs.org/docs/pages/building-your-application/data-fetching/incremental-static-regeneration#using-on-demand-revalidation)